### PR TITLE
Use %Y%m%d-%H%M Tags in ghcr, Consistent with Dockerhub

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -18,8 +18,8 @@ on:
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
+  # Manually set as repo is `coactui` while image is `coact-ui`
+  IMAGE_NAME: slaclab/coact-ui
 
 
 jobs:

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -63,6 +63,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Generate timestamp-based tag in YYYYMMDD-HHMM format (matching DockerHub pattern)
+      - name: Generate Docker tagExpand commentComment on line R67
+        id: tag
+        run: |
+          TAG=$(date +"%Y%m%d-%H%M")
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "full_tag=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG}" >> $GITHUB_OUTPUT
+
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
@@ -70,6 +78,12 @@ jobs:
         uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.tag.outputs.tag }}
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:alpine
 
-# RUN apk add --no-cache bash curl
+# Used to associate the image with a source repository outside GHA
+LABEL org.opencontainers.image.source=https://github.com/slaclab/coactui
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
Identical to slaclab/coact-api#18, converging on ghcr.io being our container registry